### PR TITLE
Update branding for new floorp projects URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,9 +147,7 @@ For more detailed information and guidance, check out our [Floorp Documentation 
 
 ### 📜 Privacy Policy
 
-- [Ablaze Privacy Policy](https://docs.ablaze.one/privacy_policy)
-
-- [Floorp Privacy Policy](https://docs.ablaze.one/floorp_privacy_policy)
+- [Floorp Privacy Policy](https://floorp.app/privacy)
 
 ### 📜 About Forks
 

--- a/gecko/branding/floorp-daylight/pref/firefox-branding.js
+++ b/gecko/branding/floorp-daylight/pref/firefox-branding.js
@@ -4,8 +4,8 @@
 
 // This file contains branding-specific prefs.
 
-pref("startup.homepage_override_url", "https://blog.ablaze.one/category/ablaze/ablaze-project/floorp/");
-pref("startup.homepage_welcome_url", "about:welcome | https://blog.ablaze.one/category/ablaze/ablaze-project/floorp/");
+pref("startup.homepage_override_url", "https://blog.floorp.app");
+pref("startup.homepage_welcome_url", "about:welcome | https://blog.floorp.app");
 pref("startup.homepage_welcome_url.additional", "https://floorp.app/privacy");
 // Interval: Time between checks for a new version (in seconds)
 pref("app.update.interval", 43200); // 12 hours

--- a/gecko/branding/floorp-daylight/pref/firefox-branding.js
+++ b/gecko/branding/floorp-daylight/pref/firefox-branding.js
@@ -17,9 +17,9 @@ pref("app.update.promptWaitTime", 691200);
 // update" link supplied in the "An update is available" page of the update
 // wizard.
 pref("app.update.url.manual", "https://floorp.app");
-pref("app.update.url.details", "https://blog.ablaze.one/category/ablaze/ablaze-project/floorp/");
-pref("app.releaseNotesURL", "https://blog.ablaze.one/category/ablaze/ablaze-project/floorp/");
-pref("app.releaseNotesURL.aboutDialog", "https://blog.ablaze.one/category/ablaze/ablaze-project/floorp/");
+pref("app.update.url.details", "https://blog.floorp.app/categories/release");
+pref("app.releaseNotesURL", "https://blog.floorp.app/categories/release");
+pref("app.releaseNotesURL.aboutDialog", "https://blog.floorp.app/categories/release");
 
 // The number of days a binary is permitted to be old
 // without checking for an update.  This assumes that

--- a/gecko/branding/floorp-daylight/pref/firefox-branding.js
+++ b/gecko/branding/floorp-daylight/pref/firefox-branding.js
@@ -6,7 +6,7 @@
 
 pref("startup.homepage_override_url", "https://blog.ablaze.one/category/ablaze/ablaze-project/floorp/");
 pref("startup.homepage_welcome_url", "about:welcome | https://blog.ablaze.one/category/ablaze/ablaze-project/floorp/");
-pref("startup.homepage_welcome_url.additional", "https://docs.ablaze.one/floorp_privacy_policy/");
+pref("startup.homepage_welcome_url.additional", "https://floorp.app/privacy");
 // Interval: Time between checks for a new version (in seconds)
 pref("app.update.interval", 43200); // 12 hours
 // Give the user x seconds to react before showing the big UI. default=192 hours

--- a/gecko/branding/floorp-official/pref/firefox-branding.js
+++ b/gecko/branding/floorp-official/pref/firefox-branding.js
@@ -20,9 +20,9 @@ pref("app.update.promptWaitTime", 691200);
 
 
 pref("app.update.url.manual", "https://floorp.app");
-pref("app.update.url.details", "https://blog.ablaze.one/category/ablaze/ablaze-project/floorp/");
-pref("app.releaseNotesURL", "https://blog.ablaze.one/category/ablaze/ablaze-project/floorp/");
-pref("app.releaseNotesURL.aboutDialog", "https://blog.ablaze.one/category/ablaze/ablaze-project/floorp/");
+pref("app.update.url.details", "https://blog.floorp.app/categories/release");
+pref("app.releaseNotesURL", "https://blog.floorp.app/categories/release");
+pref("app.releaseNotesURL.aboutDialog", "https://blog.floorp.app/categories/release");
 
 // The number of days a binary is permitted to be old
 // without checking for an update.  This assumes that

--- a/gecko/branding/floorp-official/pref/firefox-branding.js
+++ b/gecko/branding/floorp-official/pref/firefox-branding.js
@@ -4,9 +4,9 @@
 
 // This file contains branding-specific prefs.
 
-pref("startup.homepage_override_url", "https://blog.ablaze.one/category/ablaze/ablaze-project/floorp/");
-pref("floorp.startup.homepage_override_url.ja", "https://blog.ablaze.one/category/ablaze/ablaze-project/floorp/#ja");
-pref("startup.homepage_welcome_url", "about:welcome | https://blog.ablaze.one/category/ablaze/ablaze-project/floorp/");
+pref("startup.homepage_override_url", "https://blog.floorp.app");
+pref("floorp.startup.homepage_override_url.ja", "https://blog.floorp.app/ja");
+pref("startup.homepage_welcome_url", "about:welcome | https://blog.floorp.app");
 pref("startup.homepage_welcome_url.additional", "https://floorp.app/privacy");
 // Interval: Time between checks for a new version (in seconds)
 pref("app.update.interval", 43200); // 12 hours

--- a/gecko/branding/floorp-official/pref/firefox-branding.js
+++ b/gecko/branding/floorp-official/pref/firefox-branding.js
@@ -7,7 +7,7 @@
 pref("startup.homepage_override_url", "https://blog.ablaze.one/category/ablaze/ablaze-project/floorp/");
 pref("floorp.startup.homepage_override_url.ja", "https://blog.ablaze.one/category/ablaze/ablaze-project/floorp/#ja");
 pref("startup.homepage_welcome_url", "about:welcome | https://blog.ablaze.one/category/ablaze/ablaze-project/floorp/");
-pref("startup.homepage_welcome_url.additional", "https://docs.ablaze.one/floorp_privacy_policy/");
+pref("startup.homepage_welcome_url.additional", "https://floorp.app/privacy");
 // Interval: Time between checks for a new version (in seconds)
 pref("app.update.interval", 43200); // 12 hours
 // Give the user x seconds to react before showing the big UI. default=192 hours


### PR DESCRIPTION
This pull request updates URLs across the project to reflect a migration from the `ablaze.one` domain to the `floorp.app` domain. The changes ensure consistency in branding and improve user navigation by pointing to the updated Floorp resources.

### URL Updates for Branding and Documentation:

* Updated the Floorp Privacy Policy link in `README.md` to use the new `floorp.app` domain.

### URL Updates in Floorp Branding Preferences:

* In `gecko/branding/floorp-daylight/pref/firefox-branding.js`:
  - Updated homepage override and welcome URLs to use the `floorp.app` domain.
  - Updated URLs for update details and release notes to point to the new domain and appropriate categories.

* In `gecko/branding/floorp-official/pref/firefox-branding.js`:
  - Updated homepage override, welcome URLs, and Japanese-specific homepage override URL to use the `floorp.app` domain.
  - Updated URLs for update details and release notes to point to the `floorp.app` domain and relevant categories.