### PR TITLE
Update URL & hide Ablaze account section in Setting Dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,9 +147,7 @@ For more detailed information and guidance, check out our [Floorp Documentation 
 
 ### 📜 Privacy Policy
 
-- [Ablaze Privacy Policy](https://docs.ablaze.one/privacy_policy)
-
-- [Floorp Privacy Policy](https://docs.ablaze.one/floorp_privacy_policy)
+- [Floorp Privacy Policy](https://floorp.app/privacy)
 
 ### 📜 About Forks
 

--- a/gecko/branding/floorp-daylight/pref/firefox-branding.js
+++ b/gecko/branding/floorp-daylight/pref/firefox-branding.js
@@ -4,8 +4,8 @@
 
 // This file contains branding-specific prefs.
 
-pref("startup.homepage_override_url", "https://blog.ablaze.one/category/ablaze/ablaze-project/floorp/");
-pref("startup.homepage_welcome_url", "about:welcome | https://blog.ablaze.one/category/ablaze/ablaze-project/floorp/");
+pref("startup.homepage_override_url", "https://blog.floorp.app");
+pref("startup.homepage_welcome_url", "about:welcome | https://blog.floorp.app");
 pref("startup.homepage_welcome_url.additional", "https://floorp.app/privacy");
 // Interval: Time between checks for a new version (in seconds)
 pref("app.update.interval", 43200); // 12 hours

--- a/gecko/branding/floorp-daylight/pref/firefox-branding.js
+++ b/gecko/branding/floorp-daylight/pref/firefox-branding.js
@@ -17,9 +17,9 @@ pref("app.update.promptWaitTime", 691200);
 // update" link supplied in the "An update is available" page of the update
 // wizard.
 pref("app.update.url.manual", "https://floorp.app");
-pref("app.update.url.details", "https://blog.ablaze.one/category/ablaze/ablaze-project/floorp/");
-pref("app.releaseNotesURL", "https://blog.ablaze.one/category/ablaze/ablaze-project/floorp/");
-pref("app.releaseNotesURL.aboutDialog", "https://blog.ablaze.one/category/ablaze/ablaze-project/floorp/");
+pref("app.update.url.details", "https://blog.floorp.app/categories/release");
+pref("app.releaseNotesURL", "https://blog.floorp.app/categories/release");
+pref("app.releaseNotesURL.aboutDialog", "https://blog.floorp.app/categories/release");
 
 // The number of days a binary is permitted to be old
 // without checking for an update.  This assumes that

--- a/gecko/branding/floorp-daylight/pref/firefox-branding.js
+++ b/gecko/branding/floorp-daylight/pref/firefox-branding.js
@@ -6,7 +6,7 @@
 
 pref("startup.homepage_override_url", "https://blog.ablaze.one/category/ablaze/ablaze-project/floorp/");
 pref("startup.homepage_welcome_url", "about:welcome | https://blog.ablaze.one/category/ablaze/ablaze-project/floorp/");
-pref("startup.homepage_welcome_url.additional", "https://docs.ablaze.one/floorp_privacy_policy/");
+pref("startup.homepage_welcome_url.additional", "https://floorp.app/privacy");
 // Interval: Time between checks for a new version (in seconds)
 pref("app.update.interval", 43200); // 12 hours
 // Give the user x seconds to react before showing the big UI. default=192 hours

--- a/gecko/branding/floorp-official/pref/firefox-branding.js
+++ b/gecko/branding/floorp-official/pref/firefox-branding.js
@@ -20,9 +20,9 @@ pref("app.update.promptWaitTime", 691200);
 
 
 pref("app.update.url.manual", "https://floorp.app");
-pref("app.update.url.details", "https://blog.ablaze.one/category/ablaze/ablaze-project/floorp/");
-pref("app.releaseNotesURL", "https://blog.ablaze.one/category/ablaze/ablaze-project/floorp/");
-pref("app.releaseNotesURL.aboutDialog", "https://blog.ablaze.one/category/ablaze/ablaze-project/floorp/");
+pref("app.update.url.details", "https://blog.floorp.app/categories/release");
+pref("app.releaseNotesURL", "https://blog.floorp.app/categories/release");
+pref("app.releaseNotesURL.aboutDialog", "https://blog.floorp.app/categories/release");
 
 // The number of days a binary is permitted to be old
 // without checking for an update.  This assumes that

--- a/gecko/branding/floorp-official/pref/firefox-branding.js
+++ b/gecko/branding/floorp-official/pref/firefox-branding.js
@@ -4,9 +4,9 @@
 
 // This file contains branding-specific prefs.
 
-pref("startup.homepage_override_url", "https://blog.ablaze.one/category/ablaze/ablaze-project/floorp/");
-pref("floorp.startup.homepage_override_url.ja", "https://blog.ablaze.one/category/ablaze/ablaze-project/floorp/#ja");
-pref("startup.homepage_welcome_url", "about:welcome | https://blog.ablaze.one/category/ablaze/ablaze-project/floorp/");
+pref("startup.homepage_override_url", "https://blog.floorp.app");
+pref("floorp.startup.homepage_override_url.ja", "https://blog.floorp.app/ja");
+pref("startup.homepage_welcome_url", "about:welcome | https://blog.floorp.app");
 pref("startup.homepage_welcome_url.additional", "https://floorp.app/privacy");
 // Interval: Time between checks for a new version (in seconds)
 pref("app.update.interval", 43200); // 12 hours

--- a/gecko/branding/floorp-official/pref/firefox-branding.js
+++ b/gecko/branding/floorp-official/pref/firefox-branding.js
@@ -7,7 +7,7 @@
 pref("startup.homepage_override_url", "https://blog.ablaze.one/category/ablaze/ablaze-project/floorp/");
 pref("floorp.startup.homepage_override_url.ja", "https://blog.ablaze.one/category/ablaze/ablaze-project/floorp/#ja");
 pref("startup.homepage_welcome_url", "about:welcome | https://blog.ablaze.one/category/ablaze/ablaze-project/floorp/");
-pref("startup.homepage_welcome_url.additional", "https://docs.ablaze.one/floorp_privacy_policy/");
+pref("startup.homepage_welcome_url.additional", "https://floorp.app/privacy");
 // Interval: Time between checks for a new version (in seconds)
 pref("app.update.interval", 43200); // 12 hours
 // Give the user x seconds to react before showing the big UI. default=192 hours

--- a/src/apps/settings/src/app/dashboard/page.tsx
+++ b/src/apps/settings/src/app/dashboard/page.tsx
@@ -120,7 +120,7 @@ export default function Page() {
           </CardFooter>
         </Card>
 
-        <Card className="z-1">
+        <Card className="z-1 hidden">
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
               <UserRound className="size-5 text-orange-500" />

--- a/src/apps/settings/src/app/dashboard/page.tsx
+++ b/src/apps/settings/src/app/dashboard/page.tsx
@@ -84,7 +84,7 @@ export default function Page() {
           </CardContent>
           <CardFooter>
             <a
-              href="https://support.ablaze.one/setup"
+              href="https://docs.floorp.app/docs/features/"
               className="flex items-center gap-2"
             >
               <Button>


### PR DESCRIPTION
This pull request updates URLs across various files to reflect the new domain structure for the Floorp project. It also includes minor UI adjustments in the settings dashboard.

### URL Updates:

* Updated the Floorp Privacy Policy link in `README.md` to use the new domain `floorp.app` instead of `docs.ablaze.one`.
* Updated homepage and release-related URLs in `gecko/branding/floorp-daylight/pref/firefox-branding.js` to point to `floorp.app` and its subdomains. [[1]](diffhunk://#diff-53e377b3ddfa596a07411797cdbedbd62dd19b4f6de1b07df1c806e47a06603dL7-R9) [[2]](diffhunk://#diff-53e377b3ddfa596a07411797cdbedbd62dd19b4f6de1b07df1c806e47a06603dL20-R22)
* Updated homepage and release-related URLs in `gecko/branding/floorp-official/pref/firefox-branding.js` to align with the new domain structure. [[1]](diffhunk://#diff-292791af778547264db248fe1386d2e515bba3bc76d5b33bd5a8a8a09028d1e9L7-R10) [[2]](diffhunk://#diff-292791af778547264db248fe1386d2e515bba3bc76d5b33bd5a8a8a09028d1e9L23-R25)
* Changed the support link in `src/apps/settings/src/app/dashboard/page.tsx` to point to the new documentation page at `docs.floorp.app`.

### UI Adjustments:

* Hid a card element in the settings dashboard by adding the `hidden` class in `src/apps/settings/src/app/dashboard/page.tsx`.