### PR TITLE
Create a workflow to organize issues

### DIFF
--- a/.github/workflows/organize_issue.yml
+++ b/.github/workflows/organize_issue.yml
@@ -1,0 +1,24 @@
+name: Close inactive issues and PRs
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-issue-stale: 90
+          days-before-issue-close: 30
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue or Pull Request is stale because it has been open for 90 days with no activity."
+          close-issue-message: "This issue or Pull Request was closed because it has been inactive for 30 days since being marked as stale."
+          days-before-pr-stale: 90
+          days-before-pr-close: 30
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          exempt-issue-labels: "non-stale"

--- a/.github/workflows/organize_issue.yml
+++ b/.github/workflows/organize_issue.yml
@@ -2,6 +2,7 @@ name: Close inactive issues and PRs
 on:
   schedule:
     - cron: "30 1 * * *"
+  workflow_dispatch:
 
 jobs:
   close-issues:


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automatically close inactive issues and pull requests. The workflow uses the `actions/stale` action to mark issues and PRs as stale after a specified period of inactivity and then close them after an additional period.

Automation for managing inactive issues and PRs:

* [`.github/workflows/organize_issue.yml`](diffhunk://#diff-a5698adb52effdab577c9026eb8077436c5945af6c1b2584e87d92df9e2e3dfaR1-R25): Added a new workflow named "Close inactive issues and PRs" that runs on a daily schedule and can also be triggered manually. It uses the `actions/stale` action to mark issues and PRs as stale after 90 days of inactivity and close them 30 days later, with customizable messages and label exemptions.