### PR TITLE
fix(card): adjust z-index value in Card component

### DIFF
--- a/src/apps/settings/src/components/common/card.tsx
+++ b/src/apps/settings/src/components/common/card.tsx
@@ -10,7 +10,7 @@ export function Card({ children, className }: CardProps) {
   return (
     <div
       className={cn(
-        "flex flex-col bg-base-200 shadow-md border rounded border-base-300/20 dark:bg-base-600 mb-8 z-1000",
+        "flex flex-col bg-base-200 shadow-md border rounded border-base-300/20 dark:bg-base-600 mb-8 z-10",
         className,
       )}
     >


### PR DESCRIPTION
This pull request includes a minor update to the z-index value in the `Card` component to address stacking context issues.
And, it fixes #101 Problem.

* [`src/apps/settings/src/components/common/card.tsx`](diffhunk://#diff-256ebd52938466911bfabe492d29e76488fcd625bd1608eb8a161431e26c72f5L13-R13): Updated the `z-1000` class to `z-10` in the `className` property of the `Card` component to ensure proper layering behavior.