### PR TITLE
feat(workspaces): Prompt when deleting workspace

### DIFF
--- a/src/apps/main/core/common/workspaces/workspacesService.ts
+++ b/src/apps/main/core/common/workspaces/workspacesService.ts
@@ -64,12 +64,20 @@ export class WorkspacesService implements WorkspacesDataManagerBase {
 
   deleteWorkspace(workspaceID: TWorkspaceID): void {
     if (workspacesDataStore.data.size === 1) return;
-    this.tabManagerCtx.removeTabByWorkspaceId(workspaceID);
-    setWorkspacesDataStore(
-      "order",
-      (prev) => prev.filter((v) => v !== workspaceID),
+    const workspace = this.getRawWorkspace(workspaceID);
+    const result = Services.prompt.confirm(
+      window,
+      i18next.t('workspaces.modal.deleteTitle'),
+      i18next.t('workspaces.modal.deleteText', { name: workspace.name }),
     );
-    this.dataManagerCtx.deleteWorkspace(workspaceID);
+    if (result) {
+      this.tabManagerCtx.removeTabByWorkspaceId(workspaceID);
+      setWorkspacesDataStore(
+          "order",
+          (prev) => prev.filter((v) => v !== workspaceID),
+      );
+      this.dataManagerCtx.deleteWorkspace(workspaceID);
+    }
   }
 
   /**

--- a/src/apps/main/i18n/locales/en-US.json
+++ b/src/apps/main/i18n/locales/en-US.json
@@ -12,7 +12,9 @@
             "icon": "Icon",
             "edit-title": "Edit Workspace",
             "save": "Save Changes",
-            "cancel": "Cancel"
+            "cancel": "Cancel",
+            "deleteTitle": "Delete workspace",
+            "deleteText": "Please confirm to delete workspace: {{name}}"
         },
         "icons": {
             "article": "Article",


### PR DESCRIPTION
Makes the browser prompt for confirmation when deleting a workspace. I find this very useful to prevent accidental deletion.

This is a successor to: https://github.com/Floorp-Projects/Floorp-core/pull/85